### PR TITLE
Example for editable_long_text had an error.

### DIFF
--- a/app/views/pages/templates/tags.liquid.haml
+++ b/app/views/pages/templates/tags.liquid.haml
@@ -677,7 +677,7 @@
         :preserve
           &#123;&#37; editable_long_text "tagline", hint: "The tagline below the big title", priority: 1 &#37;&#125;
           Lorem ipsum (default content)
-          &#123;&#37; endeditable_short_text &#37;&#125;
+          &#123;&#37; endeditable_long_text &#37;&#125;
 
       %br
 


### PR DESCRIPTION
Was just referencing the documentation for editable_long_text and found this problem.

Example for editable_long_text had a end using the short text tag which causes a liquid parse error.
