### PR TITLE
fix editable_long_text typo error in tags.liquid.haml

### DIFF
--- a/app/views/pages/templates/tags.liquid.haml
+++ b/app/views/pages/templates/tags.liquid.haml
@@ -677,7 +677,7 @@
         :preserve
           &#123;&#37; editable_long_text "tagline", hint: "The tagline below the big title", priority: 1 &#37;&#125;
           Lorem ipsum (default content)
-          &#123;&#37; endeditable_short_text &#37;&#125;
+          &#123;&#37; endeditable_long_text &#37;&#125;
 
       %br
 


### PR DESCRIPTION
I noticed a typo error while view tags section of the documentation.

The end tag should be

endeditable_long_text

instead of

endeditable_short_text
