### PR TITLE
Update Heroku Addon command for new MongoHQ offerings

### DIFF
--- a/app/views/pages/installation/heroku.liquid.haml
+++ b/app/views/pages/installation/heroku.liquid.haml
@@ -82,7 +82,7 @@
   %a{ :href => 'http://docs.heroku.com/mongohq' } here.
 
 %pre
-  heroku addons:add mongohq:free
+  heroku addons:add mongohq:sandbox
 
 %p
   Modify the configuration for the production mongodb database in the


### PR DESCRIPTION
Hello,

I was setting up a new locomotive instance and noticed that mongohq changed their offerings on Heroku so that the documentation no longer matches.  I added the new free option to the documentation.

I have been using locomotive a lot recently and I am interested in looking for ways to contribute, not sure if this is where you maintain all the content for the doc site, but thought I would give it a go.

Robert
