### PR TITLE
Corrected wagon command to generate content type

### DIFF
--- a/app/views/pages/guides/content-types/public-form-submission.liquid.haml
+++ b/app/views/pages/guides/content-types/public-form-submission.liquid.haml
@@ -17,7 +17,7 @@ editable_elements:
   To accept forms from the public, you first must create a content type that will store the submissions.
 
       cd ~/workspace/my_first_website
-      bundle exec wagon generate customer_messages name:string email:string message:text
+      bundle exec wagon generate content_type customer_messages name:string email:string message:text
 
   Remove the data/customer_messages.yml, since you won't be pre-populating the content type with entires
 


### PR DESCRIPTION
The wagon command was missing content_type, which makes the command fail.
