### PR TITLE
Added link to templating guide

### DIFF
--- a/app/views/pages/references/tags/layout/block.liquid.haml
+++ b/app/views/pages/references/tags/layout/block.liquid.haml
@@ -27,4 +27,7 @@ position: 2
       {% endblock %}
   {% endraw %}
 
+  For more information about using the block tag, including nested blocks, check out the
+  [basics of templating guide](/guides/templating/basics).
+
 {% endblock %}


### PR DESCRIPTION
I was looking at the block tag reference and didn't see how to do nested templates. I eventually found what I needed in the basic templating guide. I added a link so people looking through the block tag reference can find this guide easier.
