### PR TITLE
Error is raised if mongodb isn't running/installed.

### DIFF
--- a/app/views/pages/guides/get-started/install-engine.liquid.haml
+++ b/app/views/pages/guides/get-started/install-engine.liquid.haml
@@ -60,7 +60,7 @@ editable_elements:
 
     Use your favorite IDE to edit the engine settings. Instructions are given as comments in setting files.
 
-    First, configure your mongodb hostname and database name in `config/mongoid.yml`.
+    First, configure your mongodb hostname and database name in `config/mongoid.yml`. **Make sure you have MongoDB installed -- [instructions here](http://docs.mongodb.org/manual/installation/).**
 
     Then configure the main settings: multisite activation, default locale, email sender (etc) in `config/initializers/locomotive.rb`.
 


### PR DESCRIPTION
bundle exec rails g locomotive:install
/Users/iMac/.rvm/gems/ruby-1.9.3-p194/gems/mongo-1.5.2/lib/mongo/connection.rb:413:in `connect': Failed to connect to a master node at localhost:27017 (Mongo::ConnectionFailure)
