### PR TITLE
Resize/DragonFly & Heroku setup

### DIFF
--- a/app/views/pages/references/filters/misc/resize.liquid.haml
+++ b/app/views/pages/references/filters/misc/resize.liquid.haml
@@ -20,8 +20,9 @@ position: 2
   {% endraw %}
 
   <div class="alert alert-info">
-    By default, the Rack::Cache middleware is called for the caching. If you host your LocomotiveCMS on Heroku, Varnish is used instead. For more information, please visit this
-    <a href="http://markevans.github.com/dragonfly/file.Caching.html">page.</a>
+    By default, the Rack::Cache middleware is called for the caching. If you host your LocomotiveCMS on Heroku please visit
+    <a href="http://markevans.github.com/dragonfly/file.Caching.html">this page</a>
+    for setup instructions.
   </div>
 
   ### Options


### PR DESCRIPTION
Varnish is no longer part of the Heroku stack. Use Rack::Cache with Memcached instead! 
