### PR TITLE
Add http to locomotivehosting.com link

### DIFF
--- a/app/views/pages/guides/get-started/install-engine.liquid.haml
+++ b/app/views/pages/guides/get-started/install-engine.liquid.haml
@@ -14,7 +14,7 @@ editable_elements:
 
   LocomotiveCMS runs as a rails engine: you need to create a Ruby On Rails app and include the LocomotiveCMS engine gem.
 
-  You can install it locally or on your own server. If you want to host your site our [hosting solution](www.locomotivehosting.com), you don't need to follow theses instructions.
+  You can install it locally or on your own server. If you want to host your site our [hosting solution](http://www.locomotivehosting.com), you don't need to follow theses instructions.
 
   # 1. Create a Ruby on Rails application
 


### PR DESCRIPTION
Add http to avoid ending up at  http://doc.locomotivecms.com/guides/get-started/www.locomotivehosting.com which of course doesn't exist
