### PR TITLE
Update references to ul to nav

### DIFF
--- a/app/views/pages/references/tags/misc/nav.liquid.haml
+++ b/app/views/pages/references/tags/misc/nav.liquid.haml
@@ -67,7 +67,7 @@ position: 1
       <tr>
         <td>no_wrapper</td>
         <td>Boolean</td>
-        <td>do not output the ul wrapper. false by default.</td>
+        <td>do not output the nav and ul wrapper tags. false by default.</td>
       </tr>
       <tr>
         <td>exclude</td>
@@ -82,12 +82,12 @@ position: 1
       <tr>
         <td>id</td>
         <td>String</td>
-        <td>css unique identifier for the ul tag. "nav" by default.</td>
+        <td>css unique identifier for the nav tag. "nav" by default.</td>
       </tr>
       <tr>
         <td>class</td>
         <td>String</td>
-        <td>class of the ul tag.</td>
+        <td>class of the nav tag.</td>
       </tr>
       <tr>
         <td>active_class</td>


### PR DESCRIPTION
Now that the nav drop creates a nav tag with a ul inside it, the id and css attributes affect the nav tag, not the ul tag. Also adjusted to state that no_wrapper removes both of these tags.
