### PR TITLE
Corrected and added to the documentation for the textile filter.

### DIFF
--- a/app/views/pages/references/filters/text/textile.liquid.haml
+++ b/app/views/pages/references/filters/text/textile.liquid.haml
@@ -10,14 +10,18 @@ position: 6
 {% block 'main/left/content' %}
 
 :markdown
-  # textile(input)
+  # textile
 
-  Convert a Markdown-formatted string into HTML.
+  The textile filter converts text formatted with [Textile](http://en.wikipedia.org/wiki/Textile) to HTML
+  using the popular ruby gem [RedCloth](http://redcloth.org/).
+  For a complete explanation of textile syntax, please visit the [Textile Reference Manual for RedCloth](http://redcloth.org/textile/).
 
-      {% raw %}{{ '### Header' | textile }}
+  ## Example
+  
+      {% raw %}{{ 'h3. Header' | textile }}
   {% endraw %}
 
-  **Example**: Returns
+  The HTML output of the example above is:
 
       <h3>Header</h3>
 


### PR DESCRIPTION
Before the documentation said the textile filter used markdown syntax. When this didn't work I looked at the source and noticed that the filter used RedCloth, which is a textile processor, not a markdown processor. I tried using textile syntax and that worked.

I corrected this in the textile filter documentation and added some helpful information.
