### PR TITLE
Pagination example incorrectly shows using the content_type object to access data

### DIFF
--- a/app/views/pages/references/tags/content/paginate.liquid.haml
+++ b/app/views/pages/references/tags/content/paginate.liquid.haml
@@ -15,7 +15,7 @@ position: 1
 
   It can be combined with the *with_scope* tag.
 
-      {% raw %}{% paginate content_type.projects by 10 %}
+      {% raw %}{% paginate contents.projects by 10 %}
         {% for project in paginate.collection %}
           {{ project.title }}
         {% endfor %}


### PR DESCRIPTION
Following the example using the content_type object to access data collections will result in an error. All other docs correctly instruct to use the contents object to access data collections.
