### PR TITLE
Updated locomotive-heroku version

### DIFF
--- a/app/views/pages/guides/hosting/heroku-hosting.liquid.haml
+++ b/app/views/pages/guides/hosting/heroku-hosting.liquid.haml
@@ -26,7 +26,7 @@ editable_elements:
 
   Open your **Gemfile** file in your LocomotiveCMS application and add the following statement right after the one about the LocomotiveCMS engine.
 
-      gem 'locomotive-heroku', '~> 0.0.2', :require => 'locomotive/heroku'
+      gem 'locomotive-heroku', '~> 0.1.0', :require => 'locomotive/heroku'
       gem 'thin', :group => 'production'
 
   While you’re at it, add the following line right before your first gem entry:


### PR DESCRIPTION
The old version 0.0.2 has a conflicting excon dependency with locomotive_cms 2.2.3.
