### PR TITLE
fixed word wrap for pre tags in Firefox

### DIFF
--- a/public/stylesheets/modules/_github.sass
+++ b/public/stylesheets/modules/_github.sass
@@ -4,6 +4,7 @@
 #main-generic
   pre
     margin-bottom: 10px
+    white-space: pre-wrap
     word-wrap: break-word
     span
       font-size: 13px


### PR DESCRIPTION
Without this extra line of CSS, word wrap doesn't work in code blocks on Firefox. A long line of text will simply overflow out of the box on the right side. Other browsers appear to work fine already.
