### PR TITLE
Fix erroneous .gif reference to correct .jpg

### DIFF
--- a/app/views/pages/references/assets.liquid.haml
+++ b/app/views/pages/references/assets.liquid.haml
@@ -14,7 +14,7 @@ position: 7
   # Images
 
   Let's say you want to add logo.jpg on your index page.
-  Add logo.gif to
+  Add logo.jpg to
 
       public/images
 


### PR DESCRIPTION
There was a reference to a `logo.gif` file `assets` documentation, when it was `logo.jpg` everywhere else. This should fix it.
