### PR TITLE
The button went to a 404

### DIFF
--- a/app/views/pages/making-blog.liquid.haml
+++ b/app/views/pages/making-blog.liquid.haml
@@ -30,6 +30,6 @@ handle: making-blog
 
 %br
 %br
-%a.orange-rounded-button{href: "/making-blog/create-wagon-site"} All set? Let's get started.
+%a.orange-rounded-button{href: "/making-blog/1-1-create-wagon-site"} All set? Let's get started.
 
 {% endblock %}


### PR DESCRIPTION
The let's get started button target url didn't match the correct one in the ul nav list on the right for the beginning of the tutorial.
