### PR TITLE
Normalize Article Typography

### DIFF
--- a/public/stylesheets/modules/_article.sass
+++ b/public/stylesheets/modules/_article.sass
@@ -1,5 +1,9 @@
 #content-column
   article
+    font-size: 15px
+    font-weight: 300
+    line-height: 24px
+
     h1
       font-size: 20px
       font-weight: normal
@@ -38,7 +42,7 @@
       em
         font-weight: normal
         text-decoration: underline
-        font-size: 14px
+        font-size: inherit
 
     ul
       +pretty-bullets("/images/bullet.png", 5px, 5px, 27px)
@@ -47,9 +51,6 @@
 
       li
         color: $light-black
-        font-size: 15px
-        line-height: 24px
-        font-weight: 300
         margin-bottom: 10px
 
         strong
@@ -59,7 +60,6 @@
           color: $deep-blue
     ol
       li
-        line-height: 18px
         margin-bottom: 10px
         a
           color: $deep-blue


### PR DESCRIPTION
Article paragraphs have font-size: 15px, line-height: 24px, and font-weight: 300. But emphasized text has font-size: 14px and ordered list items have font-size: 13px and line-height: 18px.

These discrepancies look strange to me. This commit normalizes font-size, line-height, and font-weight in article paragraph and list text. It also makes emphasized text the same size as surrounding text (though <em>'s font-weight:400 has been preserved)
