### PR TITLE
Improved article typography

### DIFF
--- a/public/stylesheets/modules/_article.sass
+++ b/public/stylesheets/modules/_article.sass
@@ -1,8 +1,9 @@
 #content-column
   article
-    font-size: 15px
-    font-weight: 300
-    line-height: 24px
+    font-size: 14px
+    font-weight: 400
+    line-height: 20px
+    color: $dark-black
 
     h1
       font-size: 20px
@@ -34,23 +35,25 @@
       background: none
 
     p
+      font-size: inherit
+      font-weight: inherit
+      line-height: inherit
+      color: inherit
+
       a
         color: $deep-blue
       strong
         font-weight: bold
 
       em
-        font-weight: normal
-        text-decoration: underline
         font-size: inherit
+        font-style: italic
 
     ul
-      +pretty-bullets("/images/bullet.png", 5px, 5px, 27px)
+      +pretty-bullets("/images/bullet.png", 5px, 5px, 20px)
       +open-sans
       margin-bottom: 10px
-
       li
-        color: $light-black
         margin-bottom: 10px
 
         strong
@@ -59,6 +62,7 @@
         a
           color: $deep-blue
     ol
+      color: inherit
       li
         margin-bottom: 10px
         a


### PR DESCRIPTION
The typography for the site looks great, but I think fonts for technical documentation articles should, above all else, be as readable as possible.

Currently, article fonts are eye-catching with slightly low contrast, a slightly large size, a light weight, and high line spacing. This commit makes article typography completely boring and readable: normal contrast, normal size, normal weight, and normal line spacing.

It also renders emphasized text as italicized text. Using underlined text for emphasized text makes them look like links.

IMHO :)
