### PR TITLE
Fix spelling of LocomotiveCMS

### DIFF
--- a/app/views/pages/get-started/create-your-first-site.liquid.haml
+++ b/app/views/pages/get-started/create-your-first-site.liquid.haml
@@ -10,7 +10,7 @@ position: 4
 
 :markdown
 
-  When you create a site with LocomotiveCMS, you do it locally first: this way you can focus on the design and the frontend code. That's what Wagon is used for: it initiates a site, runs a local http server, and eventually pushes your local code to a LocomoticeCMS engine.
+  When you create a site with LocomotiveCMS, you do it locally first: this way you can focus on the design and the frontend code. That's what Wagon is used for: it initiates a site, runs a local http server, and eventually pushes your local code to a LocomotiveCMS engine.
 
   Just in case you haven't yet, you need to [install Wagon](install-wagon) first.
 


### PR DESCRIPTION
LocomotiveCMS was spelled 'LocomoticeCMS' on line 13.
