### PR TITLE
change photo post:belongs_to:required to false

### DIFF
--- a/app/views/pages/making-blog/3-5-related-types.liquid.haml
+++ b/app/views/pages/making-blog/3-5-related-types.liquid.haml
@@ -45,7 +45,7 @@ position: 13
           - post: # Name of the field
               label: Post # Human readable name of the field
               type: belongs_to
-              required: true
+              required: false # wagon doesn't handle pushing of required relationships
               localized: false
               class_name: posts
 


### PR DESCRIPTION
wagon doesn't handle pushing of required relationships
