### PR TITLE
Fixed broken link

### DIFF
--- a/app/views/pages/get-started/heroku.liquid.haml
+++ b/app/views/pages/get-started/heroku.liquid.haml
@@ -14,7 +14,7 @@ position: 8
   We assume that you installed <strong>Heroku</strong> on your machine. Read the <a href="http://devcenter.heroku.com/articles/quickstart">Heroku quickstart guide</a> if you have not.
   </div>
   <div class="alert alert-info">
-  We also assume that you followed the <strong><a href="http://doc.locomotivecms.com/get-started/install-engine">instructions to install the engine</a></strong>.
+  We also assume that you followed the <strong><a href="http://doc.locomotivecms.com/get-started/install-engine-locally">instructions to install the engine</a></strong>.
   </div>
 
   # 1. Add the Heroku extension


### PR DESCRIPTION
(http://doc.locomotivecms.com/get-started/install-engine) 404s, so replaced with (http://doc.locomotivecms.com/get-started/install-engine-locally)
