### PR TITLE
roll back version of compass-rails

### DIFF
--- a/app/views/pages/get-started/install-engine-locally.liquid.haml
+++ b/app/views/pages/get-started/install-engine-locally.liquid.haml
@@ -116,7 +116,7 @@ position: 4
 
       -2- Add under the following line under the assets group.
 
-          gem 'compass-rails',  '~> 1.1.3'
+          gem 'compass-rails',  '~> 1.0.2'
 
       Below is a sample Gemfile with all commented out gems removed.
 


### PR DESCRIPTION
Newer versions of compass-rails does not have the css3/transform-legacy. This
is required in app/assets/stylesheets/locomotive/backoffice/menu/main.css.scss.
This will no longer be a problem on the master branch of the engine but
in version 2.5.5 it is still an issue.
