### PR TITLE
Make rails version consistent to 3.2.17

### DIFF
--- a/app/views/pages/get-started/install-engine-locally.liquid.haml
+++ b/app/views/pages/get-started/install-engine-locally.liquid.haml
@@ -316,7 +316,7 @@ position: 4
 
       Ruby on Rails can installed with the `gem install` command. Note that LocomotiveCMS Engine requires Ruby on Rails _3_, not the newer Ruby on Rails 4. Rails 4 support is coming in the next major version of LocomotiveCMS. Thus, we need the `--version` option to get the correct version
 
-      <pre><span>$ gem install rails --version=3.2.16
+      <pre><span>$ gem install rails --version=3.2.17
       Fetching: multi_json-1.9.0.gem (100%)
       Successfully installed multi_json-1.9.0
       ...blah blah blah, installing lots of gems and documentation


### PR DESCRIPTION
In the example gem file rails version is 3.2.17, but on the install rails section the version is 3.2.16
