### PR TITLE
Note that index page is never included in nav

### DIFF
--- a/app/views/pages/references/api/tags/nav.liquid.haml
+++ b/app/views/pages/references/api/tags/nav.liquid.haml
@@ -16,7 +16,7 @@ listed: true
   Moreover, it is also possible to include the nested pages.
 
   <div class="alert alert-warning">
-  Your pages must fill 2 conditions to be part of the navigation: be <b>published</b> and be <b>listed.</b>
+  Your pages must fill 2 conditions to be part of the navigation: be <b>published</b> and be <b>listed.</b> The site's index page is never included (regardless of its values for those settings).
   </div>
 
   <div class="alert alert-info">


### PR DESCRIPTION
Spent some time wondering why the nav menu wasn't working on the site I was working on, realized that it was because there weren't any other pages yet. A note like this would have saved me some frustration.

A thread that confirms this behavior (and helped me to stop pulling my hair out):
https://groups.google.com/forum/#!topic/locomotivecms/i366kcnlFdM
