### PR TITLE
Bad escaping

### DIFF
--- a/app/views/pages/references/content-types/create.liquid.haml
+++ b/app/views/pages/references/content-types/create.liquid.haml
@@ -34,7 +34,7 @@ position: 1
     </div>
 
     <div class="alert alert-info">
-    <strong>Note:</strong> The available field types are : <code>string</code>, <code>text</code>, <code>file</code>, <code>select</code>, <code>boolean</code>, <code>date</code>, <code>date_time</code>, <code>tags</code>, <code>integer</code>, <code>float</code>, <code>belongs\_to</code>, <code>has\_many</code>, <code>many\_to\_many</code>.
+    <strong>Note:</strong> The available field types are : <code>string</code>, <code>text</code>, <code>file</code>, <code>select</code>, <code>boolean</code>, <code>date</code>, <code>date_time</code>, <code>tags</code>, <code>integer</code>, <code>float</code>, <code>belongs_to</code>, <code>has_many</code>, <code>many_to_many</code>.
     </div>
 
   # Description of the YAML file


### PR DESCRIPTION
`belongs\_to` was displayed as `belongs\ to` 