### PR TITLE
Correct syntax for order_by

### DIFF
--- a/app/views/pages/references/api/tags/with_scope.liquid.haml
+++ b/app/views/pages/references/api/tags/with_scope.liquid.haml
@@ -55,7 +55,7 @@ listed: true
 
   ordering and filtering
 
-      {% raw %}{% with_scope started_at.lte: now, city: params.city, won: false, order_by: 'started_at.desc' %}
+      {% raw %}{% with_scope started_at.lte: now, city: params.city, won: false, order_by: 'started_at desc' %}
         {% assign prize = contents.prizes.first %}
       {% endwith_scope %}{% endraw %}
 


### PR DESCRIPTION
It doesn't work with dot notation