### PR TITLE
Fix human error in the standard filters doc

### DIFF
--- a/app/views/pages/references/api/filters/standard_filters.liquid.haml
+++ b/app/views/pages/references/api/filters/standard_filters.liquid.haml
@@ -49,7 +49,7 @@ position: 1
   ## Usage
 
       {% raw %}
-      {{ "testing" | upcase }}
+      {{ "testing" | capitalize }}
       Testing
       {% endraw %}
 


### PR DESCRIPTION
In the standard filters documentation, the example code for `capitalize` was having `upcase` instead of `capitalize`.