### PR TITLE
Fix links in documentation

### DIFF
--- a/app/views/snippets/nav.liquid.haml
+++ b/app/views/snippets/nav.liquid.haml
@@ -1,22 +1,22 @@
 %nav#main-nav
   .inner-container
-    %a.logo_container{ href: 'http://www.locomotivecms.com' }
+    %a.logo_container{ href: 'http://locomotivecms.com' }
       %span.logo LOCOMOTIVECMS
     #nav-toggle
       %a.icon-th-list
 
     %ul
       %li
-        %a{ href: 'http://www.locomotivecms.com/hire-us' } Hire us
+        %a{ href: 'http://locomotivecms.com/hire-us' } Hire us
 
       %li
-        %a{ href: 'http://www.locomotivecms.com/hosting', target: 'blank' } Hosting
+        %a{ href: 'http://locomotivecms.com/hosting', target: 'blank' } Hosting
 
       %li.active
         %a{ href: '/' } Documentation
 
       %li
-        %a{ href: 'http://www.locomotivecms.com/comparison' } CMS Comparison
+        %a{ href: 'http://locomotivecms.com/comparison' } CMS Comparison
 
       %li
-        %a{ href: 'http://www.locomotivecms.com/features' } Features
+        %a{ href: 'http://locomotivecms.com/features' } Features


### PR DESCRIPTION
The www domains redirect to locomotive.works, which then results in a 404.